### PR TITLE
fix:gfx memo leak

### DIFF
--- a/assets/src/components/sprite-video.ts
+++ b/assets/src/components/sprite-video.ts
@@ -90,6 +90,7 @@ export class SpriteVideo extends Component {
         }
     }
 
+    private _preSpriteFrame: SpriteFrame;
     private drawSpriteFrame() {
         let cw = this._impl.video.clientWidth,
             ch = this._impl.video.clientHeight;
@@ -148,6 +149,8 @@ export class SpriteVideo extends Component {
         }
 
         this._context.drawImage(this._impl.video, sx, sy, sw, sh, dx, dy, dw, dh);
-        this.sprite.spriteFrame = SpriteFrame.createWithImage(this._canvas);
+        if (this._preSpriteFrame) this._preSpriteFrame.texture.destroy();
+        let spriteFrame = SpriteFrame.createWithImage(this._canvas);
+        this._preSpriteFrame = this.sprite.spriteFrame = spriteFrame;
     }
 }


### PR DESCRIPTION
在渲染新的spriteframe前释放持有纹理的内存,避免内存占用无限上涨